### PR TITLE
fix: keeping full mandapId object in getAllCaterers mapping

### DIFF
--- a/src/services/catererApi.js
+++ b/src/services/catererApi.js
@@ -133,7 +133,6 @@ export const getAllCaterers = async () => {
   const response = await api.get("/get-all-caterers");
   return response.data.data.caterers.map((caterer) => ({
     ...caterer,
-    mandapId: caterer.mandapId?._id || caterer.mandapId || "",
     menuCategory: caterer.menuCategory || [],
     foodType: Array.isArray(caterer.foodType) ? caterer.foodType : [],
     about: caterer.about || "",


### PR DESCRIPTION
Previously, mandapId was being converted to just the ID string in the frontend mapper,
causing loss of populated mandap data (e.g., mandapName, venueImages).
This change ensures the full object is preserved for UI rendering.